### PR TITLE
api: generate createInstanceToken function from the updated OpenAPI schema

### DIFF
--- a/packages/api/openapi/region.yaml
+++ b/packages/api/openapi/region.yaml
@@ -191,7 +191,59 @@ paths:
               application/json:
                 schema:
                   $ref: "#/components/schemas/APIError"
-
+  /apis/android.limbar.io/v1alpha1/organizations/{organizationId}/instances/{instanceName}/tokens:
+    post:
+      summary: Create an instance token
+      operationId: createInstanceToken
+      parameters:
+        - name: organizationId
+          description: Organization ID
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: instanceName
+          description: Instance Name
+          required: true
+          in: path
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InstanceTokenCreate"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenWithValue"
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
   /livez:
     get:
       summary: Check if the server is alive
@@ -313,7 +365,6 @@ components:
         - metadata
         - token
         - status
-
     AndroidInstanceState:
       type: string
       # This enum is copied to DB schema as well.
@@ -329,3 +380,31 @@ components:
           type: string
       required:
         - message
+    InstanceTokenCreate:
+      type: object
+      properties:
+        expirationMonths:
+          type: integer
+    TokenWithValue:
+      type: object
+      properties:
+        id:
+          type: string
+        description:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        revokedAt:
+          type: string
+          format: date-time
+        token:
+          type: string
+      required:
+        - id
+        - expiresAt
+        - createdAt
+        - token

--- a/packages/api/src/region/zz_client.ts
+++ b/packages/api/src/region/zz_client.ts
@@ -60,6 +60,17 @@ export type AndroidInstanceWithToken = {
         webrtcUrl: string;
     };
 };
+export type InstanceTokenCreate = {
+    expirationMonths?: number;
+};
+export type TokenWithValue = {
+    id: string;
+    description?: string;
+    expiresAt: string;
+    createdAt: string;
+    revokedAt?: string;
+    token: string;
+};
 /**
  * Get Android instances in the region
  */
@@ -156,6 +167,31 @@ export function deleteAndroidInstance(organizationId: string, instanceName: stri
         ...opts,
         method: "DELETE"
     });
+}
+/**
+ * Create an instance token
+ */
+export function createInstanceToken(organizationId: string, instanceName: string, instanceTokenCreate?: InstanceTokenCreate, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.fetchJson<{
+        status: 200;
+        data: TokenWithValue;
+    } | {
+        status: 400;
+        data: ApiError;
+    } | {
+        status: 403;
+        data: ApiError;
+    } | {
+        status: 404;
+        data: ApiError;
+    } | {
+        status: 500;
+        data: ApiError;
+    }>(`/apis/android.limbar.io/v1alpha1/organizations/${encodeURIComponent(organizationId)}/instances/${encodeURIComponent(instanceName)}/tokens`, oazapfts.json({
+        ...opts,
+        method: "POST",
+        body: instanceTokenCreate
+    }));
 }
 /**
  * Check if the server is alive


### PR DESCRIPTION
We've added ability to create instance token for a given instance after the creation that's separate from the initial one we return.

This PR updates the OpenAPI schema and regenerates the client to add that as a function.