### PR TITLE
remote-control: remove h264 codec preference and let chrome decide

### DIFF
--- a/packages/ui/src/components/remote-control.tsx
+++ b/packages/ui/src/components/remote-control.tsx
@@ -857,34 +857,9 @@ export const RemoteControl = forwardRef<RemoteControlHandle, RemoteControlProps>
       });
 
       const rtcConfig = await rtcConfigPromise;
-
-      // Create peer connection with received configuration
       peerConnectionRef.current = new RTCPeerConnection(rtcConfig);
       peerConnectionRef.current.addTransceiver('audio', { direction: 'recvonly' });
-      
-      // Add transceivers for video and audio with H.264 preference
-      const videoTransceiver = peerConnectionRef.current.addTransceiver('video', { direction: 'recvonly' });
-      // Set codec preferences to prefer H.264
-      const supportedCodecs = RTCRtpReceiver.getCapabilities("video")?.codecs;
-      if (supportedCodecs) {
-        // Sort codecs to prefer H.264
-        const sortedCodecs = [...supportedCodecs].sort((a, b) => {
-          if (a.mimeType.toLowerCase().includes('h264')) return -1;
-          if (b.mimeType.toLowerCase().includes('h264')) return 1;
-          return 0;
-        });
-        
-        try {
-          videoTransceiver.setCodecPreferences(sortedCodecs);
-          debugLog('Codec preferences set:', sortedCodecs);
-        } catch (e) {
-          // Keep this as console.warn as it's a potentially important issue even when not debugging
-          console.warn('Failed to set codec preferences:', e);
-        }
-      }
-
-
-      // Create data channel
+      peerConnectionRef.current.addTransceiver('video', { direction: 'recvonly' });
       dataChannelRef.current = peerConnectionRef.current.createDataChannel("control", {
         ordered: true,
         negotiated: true,


### PR DESCRIPTION
We used to have only h264 codec that was hardware-accelerated but we now have native support for most common ones; vp9, vp9, av1, hevc, h264 etc.

This PR removes the codec preference the component had so that Chrome decides which one is best for given bandwidth and decoder support in the client.

Note that h264 codec we used to have didn't have adaptive bitrate capability so it was always sending full quality. The one we have does have that capability and it starts out with very low quality and gradually increase. The main goal of this PR to make Chrome start with better encoders like VP9 which can start with high quality from get to due to minimal bandwidth requirements.