### PR TITLE
Add machinery to use the Asset API

### DIFF
--- a/examples/simple/backend/package.json
+++ b/examples/simple/backend/package.json
@@ -5,7 +5,8 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "tsx watch index.ts",
+    "dev": "tsx watch index.ts",
+    "start": "tsc -b && node dist/index.js",
     "build": "tsc -b"
   },
   "author": "",

--- a/examples/simple/frontend/src/App.tsx
+++ b/examples/simple/frontend/src/App.tsx
@@ -8,6 +8,22 @@ function App() {
   } | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
+  // State to hold asset paths that user wants to upload
+  const [assetPaths, setAssetPaths] = useState<string[]>([""]);
+
+  const handleAssetPathChange = (index: number, value: string) => {
+    const newPaths = [...assetPaths];
+    newPaths[index] = value;
+    setAssetPaths(newPaths);
+  };
+
+  const addAssetInput = () => {
+    setAssetPaths([...assetPaths, ""]);
+  };
+
+  const removeAssetInput = (index: number) => {
+    setAssetPaths(assetPaths.filter((_, i) => i !== index));
+  };
   
   const createInstance = async () => {
     try {
@@ -21,7 +37,10 @@ function App() {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          name: `sdk-example`
+          name: `sdk-example`,
+          assets: assetPaths
+            .filter((p) => p.trim() !== "")
+            .map((path) => ({ path })),
         })
       });
       const data = await response.json();
@@ -46,6 +65,56 @@ function App() {
       
       {!instanceData && (
         <div style={{ marginBottom: '20px' }}>
+          {/* Asset path inputs */}
+          <div style={{ marginBottom: '20px' }}>
+            <h3>Assets</h3>
+            {assetPaths.map((path, idx) => (
+              <div
+                key={idx}
+                style={{ display: 'flex', alignItems: 'center', marginBottom: '10px' }}
+              >
+                <input
+                  type="text"
+                  placeholder="Enter asset file path"
+                  value={path}
+                  onChange={(e) => handleAssetPathChange(idx, e.target.value)}
+                  style={{ flex: 1, padding: '8px' }}
+                />
+                {assetPaths.length > 1 && (
+                  <button
+                    onClick={() => removeAssetInput(idx)}
+                    style={{
+                      marginLeft: '10px',
+                      padding: '8px 12px',
+                      backgroundColor: '#dc3545',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    Remove
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              onClick={addAssetInput}
+              style={{
+                padding: '8px 12px',
+                fontSize: '14px',
+                backgroundColor: '#28a745',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+              }}
+            >
+              Add Asset Path
+            </button>
+          </div>
+
+          {/* Create Instance button */}
           <button 
             onClick={createInstance}
             disabled={loading}

--- a/packages/api/openapi/backend.yaml
+++ b/packages/api/openapi/backend.yaml
@@ -1,0 +1,168 @@
+openapi: "3.0.0"
+info:
+  version: 0.1.0
+  title: Limbar API
+paths:
+  /organizations/{organizationId}/assets:
+    get:
+      summary: List organization's all assets with given filters. If none given, return all assets.
+      operationId: listAssets
+      parameters:
+        - name: organizationId
+          description: Organization ID
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: md5Filter
+          description: Query by file md5
+          required: false
+          in: query
+          schema:
+            type:
+              string
+        - name: nameFilter
+          description: Query by file name
+          required: false
+          in: query
+          schema:
+            type: string
+        - name: includeDownloadUrl
+          description: Toggles whether a download URL should be included in the response
+          required: false
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Asset"
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+    put:
+      summary: |-
+        If organization already has a file with given md5 a new asset referencing the same file will be created with given name.
+        If not, an upload URL will be returned where the uploaded file's md5 MUST match with the md5 provided in this request.
+        In all cases a signed download URL is returned but upload URL is returned only when you need to upload, e.g.
+        we don't have the file in your organization folder.
+      operationId: putAsset
+      parameters:
+        - name: organizationId
+          description: Organization ID
+          required: true
+          in: path
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssetPut"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetPutResult"
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+components:
+  schemas:
+    APIError:
+      type: object
+      properties:
+        message:
+          type: string
+      required:
+        - message
+    AssetPutResult:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        md5:
+          type: string
+        signedUploadUrl:
+          type: string
+        signedDownloadUrl:
+          type: string
+      required:
+        - id
+        - name
+        - md5
+        - signedDownloadUrl
+    AssetPut:
+      type: object
+      properties:
+        name:
+          type: string
+        md5:
+          type: string
+          description: |-
+            Base64-encoded md5 of the file to be uploaded. The same format as AWS expects.
+            Can be generated via "openssl dgst -md5 -binary <file path> | base64"
+      required:
+        - name
+        - md5
+    Asset:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        md5:
+          type: string
+        signedDownloadUrl:
+          type: string
+      required:
+        - id
+        - name
+        - md5

--- a/packages/api/openapi/region.yaml
+++ b/packages/api/openapi/region.yaml
@@ -346,6 +346,34 @@ components:
                 Default is 3m.
                 Providing "0" disables inactivity checks altogether.
               default: 3m
+            hardTimeout:
+              type: string
+              format: duration
+              description: |-
+                After how many minutes should the instance be terminated.
+                Example values 1m, 10m, 3h.
+                Default is "0" which means no hard timeout.
+              default: "0"
+            assets:
+              type: array
+              items:
+                type: object
+                properties:
+                  kind:
+                    type: string
+                    enum:
+                      - App
+                    default: App
+                  source:
+                    type: string
+                    enum:
+                      - URL
+                    default: URL
+                  url:
+                    type: string
+                required:
+                  - kind
+                  - source
       required:
         - metadata
     AndroidInstanceWithToken:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint .",
-    "generate": "oazapfts openapi/region.yaml src/region/zz_client.ts"
+    "generate": "oazapfts openapi/region.yaml src/region/zz_client.ts && oazapfts openapi/backend.yaml src/backend/zz_client.ts"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",

--- a/packages/api/src/backend/helpers.ts
+++ b/packages/api/src/backend/helpers.ts
@@ -26,13 +26,17 @@ export async function putAndUploadAsset(
     throw new Error(`Failed to create asset: ${assetsResponse.status} ${assetsResponse.data.message}`);
   }
   if (assetsResponse.data.signedUploadUrl) {
-    // Upload the file to the signed upload URL
     const uploadResponse = await fetch(assetsResponse.data.signedUploadUrl, {
+      headers: {
+        "Content-MD5": md5,
+        "Content-Length": data.length.toString(),
+        "Content-Type": "application/octet-stream",
+      },
       method: "PUT",
       body: data,
     });
     if (uploadResponse.status !== 200) {
-      throw new Error(`Failed to upload asset: ${uploadResponse.statusText}`);
+      throw new Error(`Failed to upload asset: ${uploadResponse.status} ${await uploadResponse.text()}`);
     }
   }
   return assetsResponse.data;

--- a/packages/api/src/backend/helpers.ts
+++ b/packages/api/src/backend/helpers.ts
@@ -1,0 +1,39 @@
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import * as oazapfts from "@oazapfts/runtime";
+import { AssetPutResult, putAsset } from "./zz_client.js";
+
+/**
+ * Uploads a file to the backend and returns the asset.
+ * @param organizationId The ID of the organization.
+ * @param filePath The path to the file to upload.
+ * @param opts Optional Oazapfts request options.
+ * @returns The asset information such as the download URL.
+ */
+export async function putAndUploadAsset(
+  organizationId: string,
+  filePath: string,
+  opts?: oazapfts.RequestOpts,
+): Promise<AssetPutResult> {
+  const data = await fs.promises.readFile(filePath);
+  const md5 = crypto.createHash("md5").update(data).digest("base64");
+  const assetsResponse = await putAsset(organizationId, {
+    name: path.basename(filePath),
+    md5,
+  }, opts);
+  if (assetsResponse.status !== 200) {
+    throw new Error(`Failed to create asset: ${assetsResponse.status} ${assetsResponse.data.message}`);
+  }
+  if (assetsResponse.data.signedUploadUrl) {
+    // Upload the file to the signed upload URL
+    const uploadResponse = await fetch(assetsResponse.data.signedUploadUrl, {
+      method: "PUT",
+      body: data,
+    });
+    if (uploadResponse.status !== 200) {
+      throw new Error(`Failed to upload asset: ${uploadResponse.statusText}`);
+    }
+  }
+  return assetsResponse.data;
+}

--- a/packages/api/src/backend/index.ts
+++ b/packages/api/src/backend/index.ts
@@ -1,0 +1,80 @@
+import type * as Oazapfts from "@oazapfts/runtime";
+import * as Generated from "./zz_client.js";
+import { putAndUploadAsset } from "./helpers.js";
+
+// Re-export ALL types from the generated file, but none of the values.
+export type * from "./zz_client.js";
+
+/**
+ * Configuration options for creating a Backend API client instance.
+ */
+export interface BackendClientOptions {
+  baseUrl: string;
+  token: string;
+  requestOpts?: Oazapfts.RequestOpts;
+}
+
+// Helper type: Extracts the parameters of a function, excluding the last 'opts' argument.
+type ExcludeOpts<T extends (...args: any) => any> = T extends (
+  ...args: [...infer P, Oazapfts.RequestOpts?]
+) => any
+  ? P
+  : never;
+
+// Helper type: Defines the structure of the client instance returned by the factory.
+// It maps the generated *functions* to methods with the same parameters (minus 'opts').
+export type BackendClient = {
+  // Iterate over keys of the generated module
+  [K in keyof typeof Generated as (typeof Generated)[K] extends (
+    // Only include keys whose values are functions
+    ...args: any
+  ) => any
+    ? K
+    : never]: (typeof Generated)[K] extends (...args: any) => any // If the value is a function, define its signature in the client type
+    ? (
+        ...args: ExcludeOpts<(typeof Generated)[K]>
+      ) => ReturnType<(typeof Generated)[K]>
+    : never; // Should not happen due to the filter above, but satisfies TS
+} & {
+  putAndUploadAsset: (
+    organizationId: string,
+    filePath: string,
+  ) => Promise<Generated.AssetPutResult>;
+};
+
+/**
+ * Creates a new Backend API client instance with its own configuration.
+ * @param options Configuration for this client instance (baseUrl, headers, etc.).
+ * @returns An object containing methods to interact with the Backend API.
+ */
+export function createBackendClient(options: BackendClientOptions): BackendClient {
+  const baseOpts: Oazapfts.RequestOpts = {
+    baseUrl: options.baseUrl,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+    },
+    ...options.requestOpts,
+  };
+  const client: Partial<BackendClient> = {};
+
+  // Iterate over keys and check if the value is a function before creating the wrapper
+  for (const key in Generated) {
+    const potentialFunc = Generated[key as keyof typeof Generated];
+    if (typeof potentialFunc === "function") {
+      // Now we know it's a function, proceed with wrapping
+      const funcName = key as keyof BackendClient;
+      const originalFunc = potentialFunc as (...args: any[]) => any;
+
+      client[funcName] = (...args: any[]) => {
+        // Call the original generated function, injecting baseOpts as the last argument
+        // Ensure we handle cases where the original function might not expect opts
+        // Although oazapfts generated functions usually do
+        return originalFunc(...args, baseOpts);
+      };
+    }
+  }
+  client.putAndUploadAsset = (organizationId: string, filePath: string) => {
+    return putAndUploadAsset(organizationId, filePath, baseOpts);
+  };
+  return client as BackendClient;
+}

--- a/packages/api/src/backend/zz_client.ts
+++ b/packages/api/src/backend/zz_client.ts
@@ -1,0 +1,91 @@
+/**
+ * Limbar API
+ * 0.1.0
+ * DO NOT MODIFY - This file has been generated using oazapfts.
+ * See https://www.npmjs.com/package/oazapfts
+ */
+import * as Oazapfts from "@oazapfts/runtime";
+import * as QS from "@oazapfts/runtime/query";
+
+const oazapfts = Oazapfts.runtime({
+    headers: {},
+    baseUrl: "/",
+});
+export type Asset = {
+    id: string;
+    name: string;
+    md5: string;
+    signedDownloadUrl?: string;
+};
+type ApiError = {
+    message: string;
+};
+export type AssetPut = {
+    name: string;
+    /** Base64-encoded md5 of the file to be uploaded. The same format as AWS expects.
+    Can be generated via "openssl dgst -md5 -binary <file path> | base64" */
+    md5: string;
+};
+export type AssetPutResult = {
+    id: string;
+    name: string;
+    md5: string;
+    signedUploadUrl?: string;
+    signedDownloadUrl: string;
+};
+/**
+ * List organization's all assets with given filters. If none given, return all assets.
+ */
+export function listAssets(organizationId: string, { md5Filter, nameFilter, includeDownloadUrl }: {
+    md5Filter?: string;
+    nameFilter?: string;
+    includeDownloadUrl?: boolean;
+} = {}, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.fetchJson<{
+        status: 200;
+        data: Asset[];
+    } | {
+        status: 403;
+        data: ApiError;
+    } | {
+        status: 404;
+        data: ApiError;
+    } | {
+        status: 500;
+        data: ApiError;
+    }>(`/organizations/${encodeURIComponent(organizationId)}/assets${QS.query(QS.explode({
+        md5Filter,
+        nameFilter,
+        includeDownloadUrl
+    }))}`, {
+        ...opts
+    });
+}
+/**
+ * If organization already has a file with given md5 a new asset referencing the same file will be created with given name.
+ * If not, an upload URL will be returned where the uploaded file's md5 MUST match with the md5 provided in this request.
+ * In all cases a signed download URL is returned but upload URL is returned only when you need to upload, e.g.
+ * we don't have the file in your organization folder.
+ */
+export function putAsset(organizationId: string, assetPut: AssetPut, opts?: Oazapfts.RequestOpts) {
+    return oazapfts.fetchJson<{
+        status: 200;
+        data: AssetPutResult;
+    } | {
+        status: 400;
+        data: ApiError;
+    } | {
+        status: 403;
+        data: ApiError;
+    } | {
+        status: 404;
+        data: ApiError;
+    } | {
+        status: 500;
+        data: ApiError;
+    }>(`/organizations/${encodeURIComponent(organizationId)}/assets`, oazapfts.json({
+        ...opts,
+        method: "PUT",
+        body: assetPut
+    }));
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./region/index.js";
 export * from "./instance/index.js";
+export * from "./backend/index.js";

--- a/packages/api/src/instance/index.ts
+++ b/packages/api/src/instance/index.ts
@@ -343,7 +343,6 @@ export async function createInstanceClient(
         type: "asset",
         url,
       };
-      console.log("Sending asset request:", assetRequest);
       ws.send(JSON.stringify(assetRequest), (err?: Error) => {
         if (err) {
           logger.error("Failed to send asset request:", err);

--- a/packages/api/src/instance/index.ts
+++ b/packages/api/src/instance/index.ts
@@ -25,6 +25,12 @@ export type InstanceClient = {
    * Returns the local TCP port and a cleanup function.
    */
   startAdbTunnel: () => Promise<Proxy>;
+  /**
+   * Send an asset URL to the instance. The instance will download the asset
+   * and process it (currently APK install is supported). Resolves on success,
+   * rejects with an Error on failure.
+   */
+  sendAsset: (url: string) => Promise<void>;
 };
 
 /**
@@ -76,9 +82,22 @@ type ScreenshotErrorResponse = {
   id: string;
 };
 
+type AssetRequest = {
+  type: "asset";
+  url: string;
+};
+
+type AssetResultResponse = {
+  type: "assetResult";
+  result: "success" | "failure" | string;
+  url: string;
+  message?: string;
+};
+
 type ServerMessage =
   | ScreenshotResponse
   | ScreenshotErrorResponse
+  | AssetResultResponse
   | { type: string; [key: string]: unknown };
 
 /**
@@ -101,6 +120,15 @@ export async function createInstanceClient(
       rejecter: (reason?: any) => void;
     }
   > = new Map();
+
+  const assetRequests: Map<
+    string,
+    {
+      resolver: (value: void | PromiseLike<void>) => void;
+      rejecter: (reason?: any) => void;
+    }
+  > = new Map();
+
   // Logger functions
   const logger = {
     debug: (...args: any[]) => {
@@ -182,6 +210,25 @@ export async function createInstanceClient(
           );
           request.rejecter(new Error(errorMessage.message));
           screenshotRequests.delete(errorMessage.id);
+          break;
+        }
+        case "assetResult": {
+          console.log("Received assetResult:", message);
+          const request = assetRequests.get(message.url as string);
+          if (!request) {
+            logger.warn(`Received assetResult for unknown or already handled url: ${message.url}`);
+            break;
+          }
+          if (message.result === "success") {
+            console.log("Asset result is success");
+            request.resolver();
+            assetRequests.delete(message.url as string);
+            break;
+          }
+          const errorMessage = typeof message.message === "string" && message.message ? message.message : `Asset processing failed: ${JSON.stringify(message)}`;
+          console.log("Asset result is failure", errorMessage);
+          request.rejecter(new Error(errorMessage));
+          assetRequests.delete(message.url as string);
           break;
         }
         default:
@@ -285,12 +332,35 @@ export async function createInstanceClient(
       }
       return { address, close };
     };
+
+    const sendAsset = async (url: string): Promise<void> => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) {
+        return Promise.reject(
+          new Error("WebSocket is not connected or connection is not open."),
+        );
+      }
+      const assetRequest: AssetRequest = {
+        type: "asset",
+        url,
+      };
+      console.log("Sending asset request:", assetRequest);
+      ws.send(JSON.stringify(assetRequest), (err?: Error) => {
+        if (err) {
+          logger.error("Failed to send asset request:", err);
+          return Promise.reject(err);
+        }
+      });
+      return new Promise<void>((resolve, reject) => {
+        assetRequests.set(url, { resolver: resolve, rejecter: reject });
+      });
+    }
     ws.on("open", () => {
       logger.debug(`Connected to ${serverAddress}`);
       resolveConnection({
         screenshot,
         disconnect,
         startAdbTunnel,
+        sendAsset,
       });
     });
   });

--- a/packages/api/src/region/helpers.ts
+++ b/packages/api/src/region/helpers.ts
@@ -82,7 +82,17 @@ export async function getOrCreateInstance(
       name: generateName(labels),
       labels,
     },
+    spec: {
+      ...body.instance.spec,
+    },
   };
+  if (body.instance.spec?.assets && body.instance.spec.assets.length > 0) {
+    instanceCreatePayload.spec!.assets = body.instance.spec.assets.map((asset) => ({
+      kind: "App",
+      source: "URL",
+      url: asset.url,
+    }));
+  }
   return putAndroidInstance(
     organizationId,
     {

--- a/packages/api/src/region/zz_client.ts
+++ b/packages/api/src/region/zz_client.ts
@@ -52,6 +52,15 @@ export type AndroidInstanceCreate = {
         Default is 3m.
         Providing "0" disables inactivity checks altogether. */
         inactivityTimeout?: string;
+        /** After how many minutes should the instance be terminated.
+        Example values 1m, 10m, 3h.
+        Default is "0" which means no hard timeout. */
+        hardTimeout?: string;
+        assets?: {
+            kind: "App";
+            source: "URL";
+            url?: string;
+        }[];
     };
 };
 export type AndroidInstanceWithToken = {


### PR DESCRIPTION
We now have Asset endpoints that allows users to upload assets, such as APK and IPA files, to our storage and order the instance to come with these assets installed.

This PR adds:
* Minimized version of backend client that calls Limbar API (not region) for asset machinery,
  * Add a helper that handles both asset creation and upload operation that includes the `md5` calculation required by the API.
* `simple` example updated to show an input box with file path and backend to call the new client functions to upload the asset and create instance with given presigned download URLs of the assets.
* `sendAsset` is added to instance client so users can order installation of an asset while the instance is running.